### PR TITLE
Copier update checkout.

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,0 +1,17 @@
+# Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
+_commit: d3d4dc7
+_src_path: gh:scipp/copier_template
+description: 'Python package to read McStas data and export as python objects in different
+    formats or as other files.
+
+
+    '
+max_python: '3.12'
+min_python: '3.10'
+namespace_package: ''
+nightly_deps: scipp,scippnexus
+orgname: mccode-dev
+prettyname: McStasToX
+projectname: McStasToX
+related_projects: Scipp,ScippNexus
+year: 2025


### PR DESCRIPTION
This is the copier answer file you get once it's copied or updated.
I think the package name should be `mcstastox` instead of `McStasTox` though... 
We can update it next time... 